### PR TITLE
250129 박세진 풀리퀘스트

### DIFF
--- a/assets/js/components/search/movieDisplay.js
+++ b/assets/js/components/search/movieDisplay.js
@@ -14,8 +14,7 @@ export const setupMovieContents = async (jsonData) => {
               ${
                 movie.Poster.indexOf("N/A") > -1
                   ? "<i class='bx bxs-image-alt'></i>"
-                  : // ? "<box-icon name='image-alt' ></box-icon>"
-                    '<img src="' + movie.Poster + '" alt=""> '
+                  : `<img src="${movie.Poster}" onerror="this.outerHTML='<i class=\\'bx bxs-image-alt\\'></i>'">`
               }
             </div>
 

--- a/assets/js/components/search/searchHandler.js
+++ b/assets/js/components/search/searchHandler.js
@@ -183,5 +183,20 @@ export const deleteButtonVisibleHandler = () =>{
       displayNone(deleteButton);
     }
   })
-  
+}
+
+// 검색 모달을 닫을때 입력값 초기화
+export const closeSearchModal = () =>{
+  const input = document.querySelector('.search-input');
+  const modalBody = document.querySelector(".modal-container"); // 모달 컨테이너 선택
+  const noSearch = document.getElementById("searchForSomething"); // 검색값이 없을때
+  const closeBtn = document.querySelector('.modal-content')
+                            .querySelector('.close-button');
+
+  closeBtn.addEventListener('click', ()=>{
+    input.value = '';
+
+    displayFlex(noSearch);
+    removeList(modalBody);
+  })
 }

--- a/assets/js/components/search/searchHandler.js
+++ b/assets/js/components/search/searchHandler.js
@@ -167,3 +167,21 @@ const removeList = (modalBody) => {
     modalBody.removeChild(list);
   }
 };
+
+// 검색 정보가 있을때 내용 삭제 버튼을 추가하는 함수
+export const deleteButtonVisibleHandler = () =>{
+  const input = document.querySelector('.search-input');
+  const deleteButton = document.querySelector('.btn-delete');
+  displayNone(deleteButton);
+
+  input.addEventListener('keyup', ()=>{
+    if( input.value.length >0 ) {
+      // deleteButton.style.display
+      displayFlex(deleteButton);
+    }else{
+      // container.removeChild( container.querySelector('.searchForSomething') );
+      displayNone(deleteButton);
+    }
+  })
+  
+}

--- a/assets/js/components/search/searchModal.js
+++ b/assets/js/components/search/searchModal.js
@@ -3,6 +3,7 @@ import {
   setFocus,
   searchTitleInit,
   deleteButtonVisibleHandler,
+  closeSearchModal,
 } from "./searchHandler.js";
 
 // 로딩시 동작하는 부분 (모달 로딩 및 초기화)
@@ -43,6 +44,7 @@ export const loadSearchModal = () => {
       if (deleteButton) {
         deleteButtonVisibleHandler();
         searchTitleInit();
+        closeSearchModal();
       }
     })
     .catch((error) => console.error("모달 fetch 오류:", error));

--- a/assets/js/components/search/searchModal.js
+++ b/assets/js/components/search/searchModal.js
@@ -2,6 +2,7 @@ import {
   setupSearchHandler,
   setFocus,
   searchTitleInit,
+  deleteButtonVisibleHandler,
 } from "./searchHandler.js";
 
 // 로딩시 동작하는 부분 (모달 로딩 및 초기화)
@@ -40,6 +41,7 @@ export const loadSearchModal = () => {
       // 삭제버튼 초기화
       const deleteButton = document.querySelector(".btn-delete");
       if (deleteButton) {
+        deleteButtonVisibleHandler();
         searchTitleInit();
       }
     })


### PR DESCRIPTION
결함아이디
UI-002 - 일부 대체이미지가 엑박으로 표시됨
UI-003 - 검색모달창을 닫아도 검색내용이 남아있음
UI-004 - 검색모달의 인풋이 없어도 내용삭제버튼 표시

내용을 수정하여 리퀘스트 드립니다.
UI-002 - img 태그의 onerror속성 사용하여 일부 엑박이미지 제거
![UI-002 수정전](https://github.com/user-attachments/assets/954fca6b-360d-46c4-a1f1-6815f4970139)
![UI-002 수정후](https://github.com/user-attachments/assets/5349fc0a-30a0-4b17-9ad2-b39711682471)
UI-003 - 검색모달창 닫기 버튼에 클릭이벤트를 추가하여 검색 기록과 검색 내용 삭제
UI-004 - 검색모달의 인풋내용이 없을때 삭제버튼 제거
